### PR TITLE
Instantiate players dynamically

### DIFF
--- a/ball.gd
+++ b/ball.gd
@@ -10,3 +10,6 @@ func _physics_process(_delta):
 	var data = get_parent().get_data(index)
 	var impulse = Vector2(data[0], -data[1])
 	set_applied_force(impulse*speed)
+
+func set_sprite(index):
+	$sprite.texture = load("res://chaser_%s.png" % index)

--- a/ball.gd
+++ b/ball.gd
@@ -11,5 +11,5 @@ func _physics_process(_delta):
 	var impulse = Vector2(data[0], -data[1])
 	set_applied_force(impulse*speed)
 
-func set_sprite(index):
-	$sprite.texture = load("res://chaser_%s.png" % index)
+func set_sprite(img_index):
+	$sprite.texture = load("res://chaser_%s.png" % img_index)

--- a/chaser.tscn
+++ b/chaser.tscn
@@ -1,0 +1,27 @@
+[gd_scene load_steps=4 format=2]
+
+[ext_resource path="res://chaser_0.png" type="Texture" id=1]
+[ext_resource path="res://ball.gd" type="Script" id=2]
+
+[sub_resource type="CircleShape2D" id=1]
+radius = 48.0
+
+[node name="chaser" type="RigidBody2D" groups=[
+"chasers",
+]]
+position = Vector2( 288.553, 229.479 )
+mass = 0.2
+gravity_scale = 0.0
+script = ExtResource( 2 )
+__meta__ = {
+"_edit_group_": true
+}
+
+[node name="collision" type="CollisionShape2D" parent="."]
+position = Vector2( 0, 0.104674 )
+scale = Vector2( 0.5, 0.5 )
+shape = SubResource( 1 )
+
+[node name="sprite" type="Sprite" parent="."]
+scale = Vector2( 4, 4 )
+texture = ExtResource( 1 )

--- a/project.godot
+++ b/project.godot
@@ -10,7 +10,6 @@ config_version=4
 
 _global_script_classes=[  ]
 _global_script_class_icons={
-
 }
 
 [application]
@@ -26,6 +25,7 @@ window/size/height=1024
 
 [rendering]
 
-quality/2d/use_pixel_snap=true
+2d/snapping/use_gpu_pixel_snap=true
 environment/default_clear_color=Color( 0.933333, 0.933333, 0.933333, 1 )
 environment/default_environment="res://default_env.tres"
+quality/2d/use_pixel_snap=true

--- a/root.gd
+++ b/root.gd
@@ -2,6 +2,8 @@ extends Node2D
 
 export var websocket_url = "ws://10.42.0.1:1338"
 
+const Chaser = preload("res://chaser.tscn")
+
 var _client = WebSocketClient.new()
 var data = {}
 
@@ -22,6 +24,15 @@ func _connected(_proto = ""):
 
 func _on_data():
 	data = JSON.parse(_client.get_peer(1).get_packet().get_string_from_utf8()).get_result()
+	
+	if get_tree().get_nodes_in_group("chasers").size() < data.keys().size():
+		var new_chaser = Chaser.instance();
+		new_chaser.index = get_tree().get_nodes_in_group("chasers").size() + 1
+		new_chaser.set_sprite(new_chaser.index)
+		# TODO: it would probably be good to have specific spawning points later
+		new_chaser.position = Vector2(600,120)
+		
+		self.add_child(new_chaser, true)
 	_client.get_peer(1).put_packet("get".to_utf8())
 
 func _process(_delta):

--- a/root.gd
+++ b/root.gd
@@ -25,7 +25,7 @@ func _connected(_proto = ""):
 func _on_data():
 	data = JSON.parse(_client.get_peer(1).get_packet().get_string_from_utf8()).get_result()
 	
-	if get_tree().get_nodes_in_group("chasers").size() < data.keys().size():
+	while get_tree().get_nodes_in_group("chasers").size() < data.keys().size():
 		var new_chaser = Chaser.instance();
 		new_chaser.index = get_tree().get_nodes_in_group("chasers").size() + 1
 		new_chaser.set_sprite(new_chaser.index)

--- a/root.tscn
+++ b/root.tscn
@@ -16,7 +16,7 @@ script = ExtResource( 3 )
 [node name="target" type="RigidBody2D" parent="." groups=[
 "targets",
 ]]
-position = Vector2( 857.19, 340.622 )
+position = Vector2( 913.351, 287.293 )
 mass = 0.2
 gravity_scale = 0.0
 contacts_reported = 1
@@ -35,16 +35,6 @@ shape = SubResource( 1 )
 [node name="sprite" type="Sprite" parent="target"]
 scale = Vector2( 4, 4 )
 texture = ExtResource( 1 )
-
-[node name="chaser_0" parent="." instance=ExtResource( 2 )]
-
-[node name="chaser_1" parent="." instance=ExtResource( 2 )]
-position = Vector2( 365.075, 429.612 )
-index = 2
-
-[node name="chaser_2" parent="." instance=ExtResource( 2 )]
-position = Vector2( 666.115, 101.663 )
-index = 3
 
 [node name="tilemap" type="TileMap" parent="."]
 scale = Vector2( 4, 4 )
@@ -67,5 +57,7 @@ smoothing_enabled = true
 smoothing_speed = 10.0
 editor_draw_drag_margin = true
 script = ExtResource( 7 )
+
+[node name="chaser" parent="." instance=ExtResource( 2 )]
 
 [connection signal="body_entered" from="target" to="target" method="_on_body_collision"]

--- a/root.tscn
+++ b/root.tscn
@@ -1,14 +1,11 @@
-[gd_scene load_steps=11 format=2]
+[gd_scene load_steps=8 format=2]
 
 [ext_resource path="res://target.png" type="Texture" id=1]
-[ext_resource path="res://ball.gd" type="Script" id=2]
+[ext_resource path="res://chaser.tscn" type="PackedScene" id=2]
 [ext_resource path="res://root.gd" type="Script" id=3]
 [ext_resource path="res://tileset.tres" type="TileSet" id=4]
-[ext_resource path="res://chaser_0.png" type="Texture" id=5]
 [ext_resource path="res://target.gd" type="Script" id=6]
 [ext_resource path="res://camera.gd" type="Script" id=7]
-[ext_resource path="res://chaser_2.png" type="Texture" id=8]
-[ext_resource path="res://chaser_1.png" type="Texture" id=9]
 
 [sub_resource type="CircleShape2D" id=1]
 radius = 48.0
@@ -39,67 +36,15 @@ shape = SubResource( 1 )
 scale = Vector2( 4, 4 )
 texture = ExtResource( 1 )
 
-[node name="chaser_0" type="RigidBody2D" parent="." groups=[
-"chasers",
-]]
-position = Vector2( 288.553, 229.479 )
-mass = 0.2
-gravity_scale = 0.0
-script = ExtResource( 2 )
-__meta__ = {
-"_edit_group_": true
-}
+[node name="chaser_0" parent="." instance=ExtResource( 2 )]
 
-[node name="collision" type="CollisionShape2D" parent="chaser_0"]
-position = Vector2( 0, 0.104674 )
-scale = Vector2( 0.5, 0.5 )
-shape = SubResource( 1 )
-
-[node name="sprite" type="Sprite" parent="chaser_0"]
-scale = Vector2( 4, 4 )
-texture = ExtResource( 5 )
-
-[node name="chaser_1" type="RigidBody2D" parent="." groups=[
-"chasers",
-]]
-position = Vector2( 640, 104 )
-mass = 0.2
-gravity_scale = 0.0
-script = ExtResource( 2 )
-__meta__ = {
-"_edit_group_": true
-}
+[node name="chaser_1" parent="." instance=ExtResource( 2 )]
+position = Vector2( 365.075, 429.612 )
 index = 2
 
-[node name="collision" type="CollisionShape2D" parent="chaser_1"]
-position = Vector2( 0, 0.104674 )
-scale = Vector2( 0.5, 0.5 )
-shape = SubResource( 1 )
-
-[node name="sprite" type="Sprite" parent="chaser_1"]
-scale = Vector2( 4, 4 )
-texture = ExtResource( 9 )
-
-[node name="chaser_2" type="RigidBody2D" parent="." groups=[
-"chasers",
-]]
-position = Vector2( 160, 368 )
-mass = 0.2
-gravity_scale = 0.0
-script = ExtResource( 2 )
-__meta__ = {
-"_edit_group_": true
-}
+[node name="chaser_2" parent="." instance=ExtResource( 2 )]
+position = Vector2( 666.115, 101.663 )
 index = 3
-
-[node name="collision" type="CollisionShape2D" parent="chaser_2"]
-position = Vector2( 0, 0.104674 )
-scale = Vector2( 0.5, 0.5 )
-shape = SubResource( 1 )
-
-[node name="sprite" type="Sprite" parent="chaser_2"]
-scale = Vector2( 4, 4 )
-texture = ExtResource( 8 )
 
 [node name="tilemap" type="TileMap" parent="."]
 scale = Vector2( 4, 4 )
@@ -122,4 +67,5 @@ smoothing_enabled = true
 smoothing_speed = 10.0
 editor_draw_drag_margin = true
 script = ExtResource( 7 )
+
 [connection signal="body_entered" from="target" to="target" method="_on_body_collision"]


### PR DESCRIPTION
This commit allows more players to be created dynamically, dependent on the number of connected controllers. It is assumed that are always at least 2 players connected (a chaser, and a target) as otherwise the game doesn't work. The third and fourth players appear when needed, and have their respective sprite set.

I have tested this as much as possible without the controllers.

Future improvements would be to make the spawn points dynamic, and possibly to drop the requirement of having 2 controllers connected (despite the game idea relying on that).